### PR TITLE
Modal Skip Button: Problem solved: End of list never reached

### DIFF
--- a/src/components/PokemonDetailed/index.js
+++ b/src/components/PokemonDetailed/index.js
@@ -64,13 +64,28 @@ const  TransitionsModal = ({ handleCloseParent, open, currentPokemon, setMyPokem
     }
       // arrow Up click through collection
       const arrowUp = () => {
-                requestpokemonDetails(currentPokemon.id+1);
-                setMyPokemon(pokemonList[currentPokemon.id]);
+                if (currentPokemon.id > 100 ) {
+                   setMyPokemon(pokemonList[3])
+                   requestpokemonDetails(currentPokemon.id-1);
+                  }
+                 else {
+                  requestpokemonDetails(currentPokemon.id+1);
+                  setMyPokemon(pokemonList[currentPokemon.id]);
+                }
     }
       // arrow Down click through collection
       const arrowDown = () => {
-                requestpokemonDetails(currentPokemon.id-1);
-                setMyPokemon(pokemonList[currentPokemon.id-2]);
+                if (currentPokemon.id < 3 ) {
+                      if (pokemonList.length > 100) {
+                        return setMyPokemon(pokemonList[100])
+                      }
+                  requestpokemonDetails(currentPokemon.id-1);
+                  setMyPokemon(pokemonList[pokemonList.length-2])
+                  }
+                 else {
+                  requestpokemonDetails(currentPokemon.id-1);
+                  setMyPokemon(pokemonList[currentPokemon.id-2]);
+                }
     }
 
       // size and weight and Image = real data seems to be missing inside of the api response


### PR DESCRIPTION
  The user will never reach the "end of the list" when he/she is  skipping through the collection of pokemons. 
  The user   will be redirect  from Pokemon 0 to pokemon 100  ,
   or from Pokemon 100 back to pokemon 1.  
   If the array is smaller than 100 Pokemons, we will regard the array.lenght hopefully (have not tested this yet)  
